### PR TITLE
Add custom routing to display user cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -109,6 +109,16 @@
   border-bottom: 1px solid #e5e7eb;
 }
 
+.user-table__row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.user-table__row:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: -2px;
+}
+
 .user-table__row:hover {
   background-color: #f8fafc;
 }
@@ -162,4 +172,98 @@
   height: 35px;
   border-radius:8px;
   border:2px solid #000000;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.content__back-button {
+  align-self: flex-start;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background-color: #f3f4f6;
+  color: #111827;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.content__back-button:hover {
+  background-color: #e5e7eb;
+}
+
+.content__back-button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+.content__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.content__description {
+  margin: 0;
+  font-size: 15px;
+  color: #4b5563;
+}
+
+.infoUser {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background-color: #f9fafb;
+}
+
+.infoUser__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.infoUser__label {
+  min-width: 90px;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.infoUser__value {
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.content__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.content__edit-button {
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: 1px solid #4f46e5;
+  background-color: #4f46e5;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.content__edit-button:hover {
+  background-color: #4338ca;
+  border-color: #4338ca;
+}
+
+.content__edit-button:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,40 +1,80 @@
+import { useCallback, useEffect, useState } from 'react'
 import './App.css'
 import { data } from './Components/data.js'
 
+const HOME_PATH = '/'
+const VISIBLE_USERS_COUNT = 12
+
 export default function App() {
+  const [path, navigate] = usePath()
+  const normalizedPath = path || HOME_PATH
+  const userMatch = normalizedPath.match(/^\/users\/(\d+)$/)
+
+  let content = null
+
+  if (userMatch) {
+    const userIndex = Number(userMatch[1])
+    const user = Number.isInteger(userIndex) ? data[userIndex] : undefined
+
+    content = <UserDetails user={user} onBack={() => navigate(HOME_PATH)} />
+  } else if (normalizedPath === HOME_PATH) {
+    content = (
+      <UsersList onSelectUser={(index) => navigate(`/users/${index}`)} />
+    )
+  } else {
+    content = <NotFound onBack={() => navigate(HOME_PATH)} />
+  }
+
   return (
     <div className="app">
       <main className="app__content">
-        <section className="card">
-          <Header />
-
-          <table className="user-table">
-            <thead>
-              <tr>
-                <th scope="col">Имя</th>
-                <th scope="col">Почта</th>
-                <th scope="col">Отдел</th>
-                <th scope="col" aria-label="Actions" />
-              </tr>
-            </thead>
-            <tbody>
-              {data.slice(0,12).map((item, index) => (
-                <TableRow key={index} {...item} />
-              ))}
-            </tbody>
-          </table>
-            <nav className='pagin'>
-              <button className='pagin__btn'>
-                ‹
-              </button>
-              <div className='pagin__page'><span></span></div>
-              <button className='pagin__btn'>
-                ›
-              </button>
-            </nav>          
-        </section>
+        <section className="card">{content}</section>
       </main>
     </div>
+  )
+}
+
+function UsersList({ onSelectUser }) {
+  const visibleUsers = data.slice(0, VISIBLE_USERS_COUNT)
+
+  return (
+    <>
+      <Header />
+
+      <table className="user-table">
+        <thead>
+          <tr>
+            <th scope="col">Имя</th>
+            <th scope="col">Почта</th>
+            <th scope="col">Отдел</th>
+            <th scope="col" aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {visibleUsers.map((item, index) => (
+            <TableRow
+              key={`${item.email}-${index}`}
+              name={item.name}
+              email={item.email}
+              group={item.group}
+              onSelect={() => onSelectUser(index)}
+            />
+          ))}
+        </tbody>
+      </table>
+
+      <nav className="pagin" aria-label="Пагинация">
+        <button className="pagin__btn" type="button" disabled>
+          ‹
+        </button>
+        <div className="pagin__page" aria-hidden="true">
+          <span>1</span>
+        </div>
+        <button className="pagin__btn" type="button" disabled>
+          ›
+        </button>
+      </nav>
+    </>
   )
 }
 
@@ -58,9 +98,21 @@ function Header() {
   )
 }
 
-function TableRow({ name, email, group }) {
+function TableRow({ name, email, group, onSelect }) {
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onSelect()
+    }
+  }
+
   return (
-    <tr className="user-table__row">
+    <tr
+      className="user-table__row"
+      onClick={onSelect}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
       <td>{name}</td>
       <td>{email}</td>
       <td>{group}</td>
@@ -71,28 +123,129 @@ function TableRow({ name, email, group }) {
   )
 }
 
-function userInfo ({name, email, group }){
-return(
-  <section className="content">
-    <h2>Информация о работнике</h2>
-    <div className="infoUser">
+function UserDetails({ user, onBack }) {
+  if (!user) {
+    return (
+      <section className="content">
+        <button
+          type="button"
+          className="content__back-button"
+          onClick={onBack}
+        >
+          ← Назад к списку
+        </button>
+        <h2 className="content__title">Пользователь не найден</h2>
+        <p className="content__description">
+          Возможно, ссылка устарела или запись была удалена.
+        </p>
+      </section>
+    )
+  }
 
-    <div className='infoUser__name'>
-      <span>Имя:</span>
-      <span>{name}</span>
+  return <UserInfo {...user} onBack={onBack} />
+}
+
+function UserInfo({ name, email, group, onBack }) {
+  return (
+    <section className="content">
+      <button
+        type="button"
+        className="content__back-button"
+        onClick={onBack}
+      >
+        ← Назад к списку
+      </button>
+
+      <h2 className="content__title">Информация о работнике</h2>
+
+      <div className="infoUser">
+        <InfoField label="Имя" value={name} />
+        <InfoField label="Почта" value={email} />
+        <InfoField label="Отдел" value={group} />
       </div>
 
-    <div className='infoUser__mail'>
-      <span>Почта:</span>
-      <span>{email}</span>
-    </div>
+      <div className="content__actions">
+        <button type="button" className="content__edit-button">
+          Редактировать
+        </button>
+      </div>
+    </section>
+  )
+}
 
-    <div className='infoUser__group'>
-      <span>Отдел:</span>
-      <span>{group}</span></div>
+function InfoField({ label, value }) {
+  return (
+    <div className="infoUser__row">
+      <span className="infoUser__label">{label}:</span>
+      <span className="infoUser__value">{value}</span>
     </div>
+  )
+}
 
-    <button>Редактировать</button>
-  </section>
-)
+function NotFound({ onBack }) {
+  return (
+    <section className="content">
+      <button
+        type="button"
+        className="content__back-button"
+        onClick={onBack}
+      >
+        ← Назад к списку
+      </button>
+      <h2 className="content__title">Страница не найдена</h2>
+      <p className="content__description">
+        Мы не нашли страницу по указанному адресу. Попробуйте вернуться на
+        главную страницу.
+      </p>
+    </section>
+  )
+}
+
+function usePath() {
+  const isBrowser = typeof window !== 'undefined'
+  const [path, setPath] = useState(() => {
+    if (!isBrowser) {
+      return HOME_PATH
+    }
+
+    return window.location.pathname || HOME_PATH
+  })
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return undefined
+    }
+
+    const handlePopState = () => {
+      setPath(window.location.pathname || HOME_PATH)
+    }
+
+    window.addEventListener('popstate', handlePopState)
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState)
+    }
+  }, [isBrowser])
+
+  const navigate = useCallback(
+    (nextPath, options = {}) => {
+      const { replace = false } = options
+
+      if (!isBrowser) {
+        setPath(nextPath)
+        return
+      }
+
+      if (replace) {
+        window.history.replaceState(null, '', nextPath)
+      } else {
+        window.history.pushState(null, '', nextPath)
+      }
+
+      setPath(nextPath)
+    },
+    [isBrowser],
+  )
+
+  return [path, navigate]
 }


### PR DESCRIPTION
## Summary
- add a lightweight routing hook to toggle between the users table, individual cards, and a fallback screen
- make table rows navigable so clicking a person opens their detailed card with a back button and edit action
- style the new user card layout and interactive rows to match the existing design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9c2633f88331a159dfd450f92ff4